### PR TITLE
Add project parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This GitHub Action installs a version of [DITA Open toolkit](https://www.dita-ot
 
 ### `transtype`
 
-Name of the transform to run. Either `build` or `transtype` is required.
+Name of the [DITA-OT transform](https://www.dita-ot.org/3.6/topics/output-formats.html) to run. One of `build` , `transtype`  or `project` is required.
 
 ### `input`
 
@@ -14,23 +14,30 @@ The location of the topic or ditamap to use to build the output. Defaults to `do
 
 ### `output-path`
 
-A string representing any additional properties to pass into the input. Defaults to `out` if not supplied.
+Location for the DITA-OT build outputs. Defaults to `out` if not supplied.
 
 ### `properties`
 
-A string representing any additional properties to pass into the input.
+A string representing any [additional parameters](https://www.dita-ot.org/3.6/parameters/parameters_intro.html) to pass into the input.
 
 ### `plugins`
 
-Comma-separated list of additional DITA-OT plugins to install.
+Comma-separated list of additional [DITA-OT plugins](https://www.dita-ot.org/3.6/topics/adding-plugins.html) to install.
 
 ### `install`
 
-The name of a bash script to run to install plugins or any other dependencies prior to running the build. Script-based alternative to `plugins`.
+The name of a bash script to run to [install plugins](https://www.dita-ot.org/3.6/topics/plugins-installing.html) or any other dependencies prior to running the build. Script-based alternative to `plugins`.
+
+### `project`
+
+Name of a DITA-OT [project file](https://www.dita-ot.org/3.6/topics/using-project-files.html) to run as an alternative to building using a
+transtype. This will only run if `transtype` is not set.
 
 ### `build`
 
-Explicit command-line input or a bash script to run the DITA-OT build.  Alternative to `transtype` and `properties`.
+Explicit command-line input or path to a bash script to run the DITA-OT build
+GitHub Action. This script will only run if  `transtype`  and `project` are
+left unset.
 
 ### `dita-ot-version`
 
@@ -79,6 +86,19 @@ Downloads an explicit version of DITA-OT to use rather than using the default. D
       input: document.ditamap
       transtype: html5
       output-path: out
+```
+
+### Build using a project file
+
+```yaml
+- name: Build HTML5 using DITA-OT
+  uses: dita-ot/dita-ot-action@master
+  with:
+      plugins : |
+        fox.jason.extend.css
+        org.doctales.xmltask
+        fox.jason.prismjs
+      project: html.xml
 ```
 
 ### Build using command line statements only

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,9 @@ inputs:
   dita-ot-version:
     description: 'The version of DITA-OT to use'
     required: false
+  project:
+    description: 'The location of the DITA-OT project file to use'
+    required: false
 branding:
   icon: 'book-open'  
   color: 'blue'
@@ -43,3 +46,4 @@ runs:
     - ${{ inputs.install }}
     - ${{ inputs.build }}
     - ${{ inputs.dita-ot-version }}
+    - ${{ inputs.project }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,6 +15,7 @@ INSTALL_FILE=/github/workspace/${INSTALL_SCRIPT}
 BUILD_SCRIPT="${7}"
 BUILD_FILE=/github/workspace/${BUILD_SCRIPT}
 DITA_OT_VERSION="${8}"
+PROJECT="${9}"
 
 
 if [ ! -z "${DITA_OT_VERSION}" ]; then 
@@ -63,6 +64,9 @@ fi
 if [ ! -z "${TRANSTYPE}" ]; then
 	echo "[INFO] Running ${TRANSTYPE} build"  
 	dita -i "${INPUT}" -o "${OUTPUT_PATH}/${TRANSTYPE}"  -f "${TRANSTYPE}" "${PROPERTIES}"
+elif [ ! -z "${PROJECT}" ]; then
+	echo "[INFO] Building project ${PROJECT}"
+	dita --project="${PROJECT}"
 elif [ -f "$BUILD_FILE" ]; then
 	echo "[INFO] Running build script"
 	"${BUILD_FILE}"


### PR DESCRIPTION
## Description

Adds an additional parameter to the dita-ot-action,  builds can be configured without `transtype`, `properties` or other filters

```yaml
 - name: Build PDF 🖨️
        uses: dita-ot/dita-ot-action@master
        with:
          install: |
            # A series of bash statements (optional)
          plugins: |
            # A set of DITA-OT Plugins (optional)
          project: pdf.xml
```

```text
[INFO] DITA-OT version 3.6.1
[INFO] Installing prerequisite DITA-OT plugins
...
[INFO] Installing using command-line
...
[INFO] Building project pdf.xml
```

## Motivation and Context

Since DITA-OT 3.4. it has been possible to build a project from the command line. This option is missing from the current dita-ot-action

## How Has This Been Tested?

Sample build run can be seen [here](https://github.com/jason-fox/test-dita-build/runs/2712851987?check_suite_focus=true)

## Type of Changes

New feature 

## Documentation and Compatibility

- What documentation changes are needed for this feature?
  _A new sample GitHub Action should be added to the docs after this is merged._
- Will this change affect backwards compatibility or other users' overrides?
 _This change is backwards compatible_

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.
