### PR TITLE
Automate update and tagging of Dockerfile

### DIFF
--- a/.github/workflows/chron.yml
+++ b/.github/workflows/chron.yml
@@ -1,0 +1,38 @@
+name: "Tag Release"
+on:
+  schedule:
+  - cron: "0 8 * * 1"
+  workflow_dispatch:
+    inputs:
+      vers:
+        description: 'Semantic Version Number'
+        required: false
+jobs:
+  tag_release:
+    runs-on: ubuntu-latest
+    name: Create Revision
+    steps:
+    - uses: actions/checkout@master
+      with:
+        persist-credentials: false
+        fetch-depth: 0
+    - name: Read release information
+      run: |
+        if [ -z ${{ github.event.inputs.vers }} ]
+        then
+          VERS=$(curl -s  https://api.github.com/repos/dita-ot/dita-ot/releases/latest | jq -r '.tag_name')
+        else
+          VERS=${{ github.event.inputs.vers }}
+        fi
+        sed -E  's/([0-9]{1,}.){1,}([0-9]){1,}/'"${VERS}"'/g' Dockerfile  > Dockerfile.tmp && mv Dockerfile.tmp Dockerfile
+        git config --global user.email "action@github.com"
+        git config --global user.name "GitHub Action"
+        git add -A .
+        git commit -m 'Docker version to '"${VERS}"'' -a
+        git tag "${VERS}" -a -m 'Release '"${VERS}"''
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      continue-on-error: true
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: ${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,17 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create GitHub release
+        uses: Roang-zero1/github-create-release-action@v3
+        with:
+          version_regex: ^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # This file is part of the DITA-OT Build GitHub Action project.
 # See the accompanying LICENSE file for applicable licenses.
 
-FROM ghcr.io/dita-ot/dita-ot:3.7.4 AS DITA_OT
+FROM ghcr.io/dita-ot/dita-ot:4.0 AS DITA_OT
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # This file is part of the DITA-OT Build GitHub Action project.
 # See the accompanying LICENSE file for applicable licenses.
 
-FROM ghcr.io/dita-ot/dita-ot:4.0 AS DITA_OT
+FROM ghcr.io/dita-ot/dita-ot:4.0.1 AS DITA_OT
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 


### PR DESCRIPTION
## Description
PR to add a Github action to update the Dockerfile with latest DITA-OT release.

There are two modes of operation.

- `workflow_dispatch` to manually add a tag - this can be tested by adding the 4.0 tag and 4.0.1 release.
-  `schedule` - once a week the task will check for a new release.

## Motivation and Context

Fixes #5

## How Has This Been Tested?

Test runs can be seen [here](https://github.com/jason-fox/dita-build-action/actions/workflows/chron.yml)

## Type of Changes

New feature _(non-breaking change which adds functionality)_


