### PR TITLE
Clarify commit message for version bumps

### DIFF
--- a/.github/workflows/chron.yml
+++ b/.github/workflows/chron.yml
@@ -28,7 +28,7 @@ jobs:
         git config --global user.email "action@github.com"
         git config --global user.name "GitHub Action"
         git add -A .
-        git commit -m 'Docker version to '"${VERS}"'' -a || true
+        git commit -m 'Bump Docker image version to '"${VERS}"'' -a || true
         git tag "${VERS}" -a -m 'Release '"${VERS}"'' || true
     - name: Push changes
       uses: ad-m/github-push-action@master


### PR DESCRIPTION
The current commit message for the scheduled GitHub Action sounds like it’s the version of Docker itself that’s being incremented.

This commit adjusts the message to clarify that it’s the DITA-OT version in the image.